### PR TITLE
Return an empty collection instead of null in HistoryController #107

### DIFF
--- a/src/main/java/app/fitbuddy/operation/controller/HistoryController.java
+++ b/src/main/java/app/fitbuddy/operation/controller/HistoryController.java
@@ -3,6 +3,7 @@ package app.fitbuddy.operation.controller;
 import java.time.LocalDate;
 import java.time.format.DateTimeParseException;
 import java.util.List;
+import java.util.Collections;
 
 import javax.validation.Valid;
 
@@ -77,7 +78,7 @@ public class HistoryController {
 				return historyDtos;
 			}
 		}
-		return null;
+		return Collections.emptyList();
 	}
 	
 	@PutMapping("{id}")


### PR DESCRIPTION
changed return statement : return an empty collection instead of null .

## Summary 
               changed return statement : return an empty collection instead of null . 
               as we don't need to write explicitly test for nullity .
## Close issue(s) 
              Close #107 