### PR TITLE
Add unit tests for src/main/java/app/fitbuddy/operation/service/NewUserService.java

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,10 @@ https://fitbuddy-demo.herokuapp.com/
 
 <div align="center">
 
-<img src="https://mepox.github.io/projects/fitbuddy/fitbuddy_login.jpg" width=200>
-<img src="https://mepox.github.io/projects/fitbuddy/fitbuddy_register.jpg" width=200>
-<img src="https://mepox.github.io/projects/fitbuddy/fitbuddy_history.jpg" width=200>
-<img src="https://mepox.github.io/projects/fitbuddy/fitbuddy_exercises.jpg" width=200>
+<img src="https://mepox.github.io/projects/fitbuddy/fitbuddy_login.png" width=200>
+<img src="https://mepox.github.io/projects/fitbuddy/fitbuddy_register.png" width=200>
+<img src="https://mepox.github.io/projects/fitbuddy/fitbuddy_history.png" width=200>
+<img src="https://mepox.github.io/projects/fitbuddy/fitbuddy_exercises.png" width=200>
 
 </div>
 

--- a/src/main/java/app/fitbuddy/operation/service/NewUserService.java
+++ b/src/main/java/app/fitbuddy/operation/service/NewUserService.java
@@ -1,5 +1,6 @@
 package app.fitbuddy.operation.service;
 
+import app.fitbuddy.exception.FitBuddyException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -21,8 +22,11 @@ public class NewUserService {
 	}
 	
 	public void addDefaultExercises(Integer appUserId) {
+		if (appUserId == null || appUserId < 0) {
+			throw new FitBuddyException("Internal server error - appUserId is not correct");
+		}
 		Iterable<DefaultExercise> defaultExercises = defaultExerciseRepository.findAll();
-		
+
 		for (DefaultExercise defaultExercise : defaultExercises) {
 			exerciseCrudService.create(new ExerciseDto(null, defaultExercise.getName(), appUserId));
 		}

--- a/src/test/java/app/fitbuddy/operation/service/NewUserServiceTest.java
+++ b/src/test/java/app/fitbuddy/operation/service/NewUserServiceTest.java
@@ -4,7 +4,6 @@ import app.fitbuddy.dto.ExerciseDto;
 import app.fitbuddy.jpa.entity.DefaultExercise;
 import app.fitbuddy.jpa.repository.DefaultExerciseCrudRepository;
 import app.fitbuddy.jpa.service.crud.ExerciseCrudService;
-import app.fitbuddy.operation.service.NewUserService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/src/test/java/app/fitbuddy/operation/service/NewUserServiceTest.java
+++ b/src/test/java/app/fitbuddy/operation/service/NewUserServiceTest.java
@@ -1,6 +1,7 @@
 package app.fitbuddy.operation.service;
 
 import app.fitbuddy.dto.ExerciseDto;
+import app.fitbuddy.exception.FitBuddyException;
 import app.fitbuddy.jpa.entity.DefaultExercise;
 import app.fitbuddy.jpa.repository.DefaultExerciseCrudRepository;
 import app.fitbuddy.jpa.service.crud.ExerciseCrudService;
@@ -15,6 +16,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
@@ -25,13 +27,10 @@ public class NewUserServiceTest {
 	@Mock	DefaultExerciseCrudRepository defaultExerciseCrudRepository;
 	@Mock	ExerciseCrudService exerciseCrudService;
 
-	@BeforeEach
-	public void setUp() {
-		when(defaultExerciseCrudRepository.findAll()).thenReturn(dummyDefaultExercises());
-	}
-
 	@Test
 	public void newUser_whenAddsDefaultExercises_shouldFindAllDefaultExercises() {
+		when(defaultExerciseCrudRepository.findAll()).thenReturn(dummyDefaultExercises());
+
 		newUserService.addDefaultExercises(DUMMY_USER_ID);
 
 		verify(defaultExerciseCrudRepository).findAll();
@@ -39,6 +38,8 @@ public class NewUserServiceTest {
 
 	@Test
 	public void newUser_whenAddsDefaultExercises_shouldCreateDtoForEachDefaultExercise() {
+		when(defaultExerciseCrudRepository.findAll()).thenReturn(dummyDefaultExercises());
+
 		newUserService.addDefaultExercises(DUMMY_USER_ID);
 
 		verify(exerciseCrudService, times(dummyDefaultExercises().size())).create(any());
@@ -46,6 +47,7 @@ public class NewUserServiceTest {
 
 	@Test
 	public void newUser_whenAddsDefaultExercises_shouldCreateCorrespondingExerciseDtoFromDefaultExercises() {
+		when(defaultExerciseCrudRepository.findAll()).thenReturn(dummyDefaultExercises());
 		ArgumentCaptor<ExerciseDto> exerciseDtoCaptor = ArgumentCaptor.forClass(ExerciseDto.class);
 
 		newUserService.addDefaultExercises(DUMMY_USER_ID);
@@ -57,6 +59,20 @@ public class NewUserServiceTest {
 					assertTrue(hasCorrespondingDto(capturedExerciseDto, dummyDefaultExercise));
 				}
 		);
+	}
+
+	@Test
+	public void newUser_whenAppUserIsNull_shouldThrowException() {
+		assertThrows(FitBuddyException.class, () -> {
+			newUserService.addDefaultExercises(null);
+		});
+	}
+
+	@Test
+	public void newUser_whenAppUserIsNegative_shouldThrowException() {
+		assertThrows(FitBuddyException.class, () -> {
+			newUserService.addDefaultExercises(-7);
+		});
 	}
 
 	/**

--- a/src/test/java/app/fitbuddy/operation/service/NewUserServiceTest.java
+++ b/src/test/java/app/fitbuddy/operation/service/NewUserServiceTest.java
@@ -4,6 +4,7 @@ import app.fitbuddy.dto.ExerciseDto;
 import app.fitbuddy.jpa.entity.DefaultExercise;
 import app.fitbuddy.jpa.repository.DefaultExerciseCrudRepository;
 import app.fitbuddy.jpa.service.crud.ExerciseCrudService;
+import app.fitbuddy.testhelper.DefaultExerciseTestHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -72,16 +73,10 @@ public class NewUserServiceTest {
 
 	private List<DefaultExercise> dummyDefaultExercises() {
 		return List.of(
-				defaultExercise(17, "walk out and squats"),
-				defaultExercise(88, "plank"),
-				defaultExercise(7, "push ups")
+				DefaultExerciseTestHelper.getMockDefaultExercise(17, "walk out and squats"),
+				DefaultExerciseTestHelper.getMockDefaultExercise(88, "plank"),
+				DefaultExerciseTestHelper.getMockDefaultExercise(7, "push ups")
 		);
 	}
 
-	private DefaultExercise defaultExercise(int id, String name) {
-		DefaultExercise defaultExercise = new DefaultExercise();
-		defaultExercise.setId(id);
-		defaultExercise.setName(name);
-		return defaultExercise;
-	}
 }

--- a/src/test/java/app/fitbuddy/operation/service/NewUserServiceTest.java
+++ b/src/test/java/app/fitbuddy/operation/service/NewUserServiceTest.java
@@ -6,16 +6,17 @@ import app.fitbuddy.jpa.entity.DefaultExercise;
 import app.fitbuddy.jpa.repository.DefaultExerciseCrudRepository;
 import app.fitbuddy.jpa.service.crud.ExerciseCrudService;
 import app.fitbuddy.testhelper.DefaultExerciseTestHelper;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
+
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.beans.factory.annotation.Value;
 
 import java.util.List;
 

--- a/src/test/java/app/fitbuddy/operation/service/NewUserServiceTest.java
+++ b/src/test/java/app/fitbuddy/operation/service/NewUserServiceTest.java
@@ -1,0 +1,88 @@
+package app.fitbuddy.operation.service;
+
+import app.fitbuddy.dto.ExerciseDto;
+import app.fitbuddy.jpa.entity.DefaultExercise;
+import app.fitbuddy.jpa.repository.DefaultExerciseCrudRepository;
+import app.fitbuddy.jpa.service.crud.ExerciseCrudService;
+import app.fitbuddy.operation.service.NewUserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class NewUserServiceTest {
+	private final static int DUMMY_USER_ID = 17;
+	@InjectMocks	NewUserService newUserService;
+	@Mock	DefaultExerciseCrudRepository defaultExerciseCrudRepository;
+	@Mock	ExerciseCrudService exerciseCrudService;
+
+	@BeforeEach
+	public void setUp() {
+		when(defaultExerciseCrudRepository.findAll()).thenReturn(dummyDefaultExercises());
+	}
+
+	@Test
+	public void newUser_whenAddsDefaultExercises_shouldFindAllDefaultExercises() {
+		newUserService.addDefaultExercises(DUMMY_USER_ID);
+
+		verify(defaultExerciseCrudRepository).findAll();
+	}
+
+	@Test
+	public void newUser_whenAddsDefaultExercises_shouldCreateDtoForEachDefaultExercise() {
+		newUserService.addDefaultExercises(DUMMY_USER_ID);
+
+		verify(exerciseCrudService, times(dummyDefaultExercises().size())).create(any());
+	}
+
+	@Test
+	public void newUser_whenAddsDefaultExercises_shouldCreateCorrespondingExerciseDtoFromDefaultExercises() {
+		ArgumentCaptor<ExerciseDto> exerciseDtoCaptor = ArgumentCaptor.forClass(ExerciseDto.class);
+
+		newUserService.addDefaultExercises(DUMMY_USER_ID);
+
+		verify(exerciseCrudService, times(dummyDefaultExercises().size())).create(exerciseDtoCaptor.capture());
+		List<ExerciseDto> capturedExerciseDto = exerciseDtoCaptor.getAllValues();
+		dummyDefaultExercises().forEach(
+				dummyDefaultExercise -> {
+					assertTrue(hasCorrespondingDto(capturedExerciseDto, dummyDefaultExercise));
+				}
+		);
+	}
+
+	/**
+	 * Checks that captured ExerciseDto list contains an exercise with expected name and appUserId DUMMY_USER_ID
+	 */
+	private boolean hasCorrespondingDto(List<ExerciseDto> capturedExerciseDto,
+										DefaultExercise defaultExercise) {
+		return capturedExerciseDto.stream()
+				.anyMatch(dto -> {
+					return dto.getName().equals(defaultExercise.getName()) &&
+							dto.getAppUserId().equals(DUMMY_USER_ID);
+				});
+	}
+
+	private List<DefaultExercise> dummyDefaultExercises() {
+		return List.of(
+				defaultExercise(17, "walk out and squats"),
+				defaultExercise(88, "plank"),
+				defaultExercise(7, "push ups")
+		);
+	}
+
+	private DefaultExercise defaultExercise(int id, String name) {
+		DefaultExercise defaultExercise = new DefaultExercise();
+		defaultExercise.setId(id);
+		defaultExercise.setName(name);
+		return defaultExercise;
+	}
+}

--- a/src/test/java/app/fitbuddy/operation/service/NewUserServiceTest.java
+++ b/src/test/java/app/fitbuddy/operation/service/NewUserServiceTest.java
@@ -66,7 +66,7 @@ public class NewUserServiceTest {
 										DefaultExercise defaultExercise) {
 		return capturedExerciseDto.stream()
 				.anyMatch(dto -> {
-					return dto.getName().equals(defaultExercise.getName()) &&
+					return DefaultExerciseTestHelper.isEqual(dto, defaultExercise) &&
 							dto.getAppUserId().equals(DUMMY_USER_ID);
 				});
 	}

--- a/src/test/java/app/fitbuddy/operation/service/NewUserServiceTest.java
+++ b/src/test/java/app/fitbuddy/operation/service/NewUserServiceTest.java
@@ -6,13 +6,16 @@ import app.fitbuddy.jpa.entity.DefaultExercise;
 import app.fitbuddy.jpa.repository.DefaultExerciseCrudRepository;
 import app.fitbuddy.jpa.service.crud.ExerciseCrudService;
 import app.fitbuddy.testhelper.DefaultExerciseTestHelper;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Value;
 
 import java.util.List;
 
@@ -61,17 +64,12 @@ public class NewUserServiceTest {
 		);
 	}
 
-	@Test
-	public void newUser_whenAppUserIsNull_shouldThrowException() {
+	@ParameterizedTest
+	@NullSource
+	@ValueSource(ints = {-7, -1, -1000001})
+	public void newUser_whenAppUserIsNullOrNegative_shouldThrowException(Integer appUserId) {
 		assertThrows(FitBuddyException.class, () -> {
-			newUserService.addDefaultExercises(null);
-		});
-	}
-
-	@Test
-	public void newUser_whenAppUserIsNegative_shouldThrowException() {
-		assertThrows(FitBuddyException.class, () -> {
-			newUserService.addDefaultExercises(-7);
+			newUserService.addDefaultExercises(appUserId);
 		});
 	}
 
@@ -81,10 +79,8 @@ public class NewUserServiceTest {
 	private boolean hasCorrespondingDto(List<ExerciseDto> capturedExerciseDto,
 										DefaultExercise defaultExercise) {
 		return capturedExerciseDto.stream()
-				.anyMatch(dto -> {
-					return DefaultExerciseTestHelper.isEqual(dto, defaultExercise) &&
-							dto.getAppUserId().equals(DUMMY_USER_ID);
-				});
+				.anyMatch(dto -> DefaultExerciseTestHelper.isEqual(dto, defaultExercise) &&
+						dto.getAppUserId().equals(DUMMY_USER_ID));
 	}
 
 	private List<DefaultExercise> dummyDefaultExercises() {

--- a/src/test/java/app/fitbuddy/testhelper/DefaultExerciseTestHelper.java
+++ b/src/test/java/app/fitbuddy/testhelper/DefaultExerciseTestHelper.java
@@ -1,6 +1,8 @@
 package app.fitbuddy.testhelper;
 
+import app.fitbuddy.dto.ExerciseDto;
 import app.fitbuddy.jpa.entity.DefaultExercise;
+import app.fitbuddy.jpa.entity.Exercise;
 
 public class DefaultExerciseTestHelper {
 	
@@ -16,6 +18,14 @@ public class DefaultExerciseTestHelper {
 		defaultExercise.setId(id);
 		defaultExercise.setName(name);
 		return defaultExercise;
+	}
+
+	public static boolean isEqual(ExerciseDto exerciseDto, DefaultExercise exercise) {
+		return exerciseDto.getName().equals(exercise.getName());
+	}
+
+	public static boolean isEqual(DefaultExercise exercise, ExerciseDto exerciseDto) {
+		return isEqual(exerciseDto, exercise);
 	}
 
 }

--- a/src/test/java/app/fitbuddy/testhelper/DefaultExerciseTestHelper.java
+++ b/src/test/java/app/fitbuddy/testhelper/DefaultExerciseTestHelper.java
@@ -2,7 +2,6 @@ package app.fitbuddy.testhelper;
 
 import app.fitbuddy.dto.ExerciseDto;
 import app.fitbuddy.jpa.entity.DefaultExercise;
-import app.fitbuddy.jpa.entity.Exercise;
 
 public class DefaultExerciseTestHelper {
 	


### PR DESCRIPTION
## Summary <!-- Add a brief description of this PR below this line -->

1. The class `app.fitbuddy.jpa.entity.DefaultExercise` does not have `@RequiredArgsConstructor` Lombok annotation or the constructor with `id` and `name` parameters so it's kinda hard to create dummy instances for testing. 
I was thinking about extending it with another test class that has such constructor (decorator pattern) for testing purpose but maybe it's a bad idea
Is it possible to add all-args constructor to `DefaultExercise` and if it is could I open the corresponding issue?

2. What should the `NewUserService` bean do when `addDefaultExercises` method is invoked with appUserId null or negative value? I haven't write the corresponding tests yet


## Close issue(s) <!-- Add "Close" and the issue number below this line, for example: "Close #123" -->
Close #110