### PR TITLE
CrudServices update should ignore the same entity for name checks

### DIFF
--- a/src/main/java/app/fitbuddy/service/crud/AppUserCrudService.java
+++ b/src/main/java/app/fitbuddy/service/crud/AppUserCrudService.java
@@ -71,10 +71,9 @@ public class AppUserCrudService implements CrudService<AppUserRequestDTO, AppUse
 		if (optionalExistingAppUser.isEmpty()) {
 			return null;
 		}
-		if (!optionalExistingAppUser.get().getName().equals(updateDTO.getName())) {
-			if (appUserRepository.findByName(updateDTO.getName()).isPresent()) {
-				throw new FitBuddyException("Username already exists.");
-			}
+		if (!optionalExistingAppUser.get().getName().equals(updateDTO.getName()) &&
+			appUserRepository.findByName(updateDTO.getName()).isPresent()) {
+				throw new FitBuddyException("Username already exists.");			
 		}
 		AppUser savedAppUser = appUserRepository.save(
 				appUserMapperService.applyUpdateDtoToEntity(optionalExistingAppUser.get(), updateDTO));		

--- a/src/main/java/app/fitbuddy/service/crud/AppUserCrudService.java
+++ b/src/main/java/app/fitbuddy/service/crud/AppUserCrudService.java
@@ -71,8 +71,10 @@ public class AppUserCrudService implements CrudService<AppUserRequestDTO, AppUse
 		if (optionalExistingAppUser.isEmpty()) {
 			return null;
 		}
-		if (appUserRepository.findByName(updateDTO.getName()).isPresent()) {
-			throw new FitBuddyException("Username already exists.");
+		if (!optionalExistingAppUser.get().getName().equals(updateDTO.getName())) {
+			if (appUserRepository.findByName(updateDTO.getName()).isPresent()) {
+				throw new FitBuddyException("Username already exists.");
+			}
 		}
 		AppUser savedAppUser = appUserRepository.save(
 				appUserMapperService.applyUpdateDtoToEntity(optionalExistingAppUser.get(), updateDTO));		

--- a/src/main/java/app/fitbuddy/service/crud/ExerciseCrudService.java
+++ b/src/main/java/app/fitbuddy/service/crud/ExerciseCrudService.java
@@ -65,9 +65,11 @@ public class ExerciseCrudService implements CrudService<ExerciseRequestDTO, Exer
 		if (optionalExistingExercise.isEmpty()) {
 			return null;
 		}
-		if (exerciseRepository.findByName(updateDTO.getName()).isPresent()) {
-			throw new FitBuddyException("Exercise name already exists.");
-		}
+		if (!optionalExistingExercise.get().getName().equals(updateDTO.getName())) {
+			if (exerciseRepository.findByName(updateDTO.getName()).isPresent()) {
+				throw new FitBuddyException("Exercise name already exists.");
+			}
+		}		
 		Exercise savedExercise = exerciseRepository.save(
 				exerciseMapperService.applyUpdateDtoToEntity(optionalExistingExercise.get(), updateDTO));
 		return exerciseMapperService.entityToResponseDto(savedExercise);

--- a/src/main/java/app/fitbuddy/service/crud/ExerciseCrudService.java
+++ b/src/main/java/app/fitbuddy/service/crud/ExerciseCrudService.java
@@ -65,10 +65,9 @@ public class ExerciseCrudService implements CrudService<ExerciseRequestDTO, Exer
 		if (optionalExistingExercise.isEmpty()) {
 			return null;
 		}
-		if (!optionalExistingExercise.get().getName().equals(updateDTO.getName())) {
-			if (exerciseRepository.findByName(updateDTO.getName()).isPresent()) {
-				throw new FitBuddyException("Exercise name already exists.");
-			}
+		if (!optionalExistingExercise.get().getName().equals(updateDTO.getName()) &&
+			exerciseRepository.findByName(updateDTO.getName()).isPresent()) {
+				throw new FitBuddyException("Exercise name already exists.");			
 		}		
 		Exercise savedExercise = exerciseRepository.save(
 				exerciseMapperService.applyUpdateDtoToEntity(optionalExistingExercise.get(), updateDTO));

--- a/src/main/java/app/fitbuddy/service/crud/RoleCrudService.java
+++ b/src/main/java/app/fitbuddy/service/crud/RoleCrudService.java
@@ -71,8 +71,10 @@ public class RoleCrudService implements CrudService<RoleRequestDTO, RoleResponse
 		if (optionalExistingRole.isEmpty()) {
 			return null;
 		}
-		if (roleRepository.findByName(updateDTO.getName()).isPresent()) {
-			throw new FitBuddyException("Role name already exists.");
+		if (!optionalExistingRole.get().getName().equals(updateDTO.getName())) {
+			if (roleRepository.findByName(updateDTO.getName()).isPresent()) {
+				throw new FitBuddyException("Role name already exists.");
+			}
 		}
 		Role savedRole = roleRepository.save(
 				roleMapperService.applyUpdateDtoToEntity(optionalExistingRole.get(), updateDTO));

--- a/src/main/java/app/fitbuddy/service/crud/RoleCrudService.java
+++ b/src/main/java/app/fitbuddy/service/crud/RoleCrudService.java
@@ -71,10 +71,9 @@ public class RoleCrudService implements CrudService<RoleRequestDTO, RoleResponse
 		if (optionalExistingRole.isEmpty()) {
 			return null;
 		}
-		if (!optionalExistingRole.get().getName().equals(updateDTO.getName())) {
-			if (roleRepository.findByName(updateDTO.getName()).isPresent()) {
+		if (!optionalExistingRole.get().getName().equals(updateDTO.getName()) &&
+			roleRepository.findByName(updateDTO.getName()).isPresent()) {
 				throw new FitBuddyException("Role name already exists.");
-			}
 		}
 		Role savedRole = roleRepository.save(
 				roleMapperService.applyUpdateDtoToEntity(optionalExistingRole.get(), updateDTO));


### PR DESCRIPTION
## Summary <!-- Add a brief description of this PR below this line -->
CrudServices update should ignore the same entity for name checks

## Close issue(s) <!-- Add "Close" and the issue number below this line, for example: "Close #123" -->
Close #151 