### PR TITLE
Issue#131

### DIFF
--- a/src/main/java/app/fitbuddy/dto/history/HistoryRequestDTO.java
+++ b/src/main/java/app/fitbuddy/dto/history/HistoryRequestDTO.java
@@ -1,9 +1,6 @@
 package app.fitbuddy.dto.history;
 
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.Positive;
-import javax.validation.constraints.PositiveOrZero;
-import javax.validation.constraints.Size;
+import javax.validation.constraints.*;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
@@ -28,8 +25,16 @@ public class HistoryRequestDTO {
 	
 	@Positive
 	private Integer reps;
-	
-	// TODO: regex pattern validation
+
+	/**
+	 * Matches the yyyy-mm-dd format.
+	 * Where year is limited to a range of 1900-2999.
+	 * Matches a month number in a range of 01-12, and a day number in a range of 01-31.
+	 *
+	 * @link https://www.baeldung.com/java-date-regular-expressions
+	 * Used simple implementation from the paragraph 3.2 that do not matches leap years and 30-days months.
+ 	 */
+	@Pattern(regexp = "^((19|2[0-9])[0-9]{2})-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])$")
 	private String createdOn;
 
 }

--- a/src/main/java/app/fitbuddy/dto/history/HistoryRequestDTO.java
+++ b/src/main/java/app/fitbuddy/dto/history/HistoryRequestDTO.java
@@ -1,6 +1,10 @@
 package app.fitbuddy.dto.history;
 
-import javax.validation.constraints.*;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Positive;
+import javax.validation.constraints.PositiveOrZero;
+import javax.validation.constraints.Size;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 

--- a/src/test/java/app/fitbuddy/controller/crud/HistoryControllerTest.java
+++ b/src/test/java/app/fitbuddy/controller/crud/HistoryControllerTest.java
@@ -66,20 +66,20 @@ class HistoryControllerTest {
 			.andExpect(status().is(302));			
 		}		
 		
-		/*@ParameterizedTest
+		@ParameterizedTest
 		@ValueSource(strings = {"abc", "1-1-2022", "01-01-2022", "2022-1-1", "2022-13-01", "2022-01-32"})
-		@WithMockUser(authorities = {"USER", "ADMIN"})		
+		@WithMockUser(authorities = {"USER", "ADMIN"})
 		void whenDateIsNotCorrect_shouldReturnBadRequest(String strDate) throws Exception {
 			HistoryRequestDTO requestDTO = new HistoryRequestDTO(0, "exerciseName", 11, 111, strDate);
 			AppUserResponseDTO appUserResponseDTO = new AppUserResponseDTO(11, "name", "password", "roleName");
-			
+
 			when(appUserCrudService.readByName(anyString())).thenReturn(appUserResponseDTO);
-			
+
 			mockMvc.perform(post(API_PATH)
 					.contentType(MediaType.APPLICATION_JSON)
-					.content(objectMapper.writeValueAsString(requestDTO)))			
+					.content(objectMapper.writeValueAsString(requestDTO)))
 			.andExpect(status().isBadRequest());
-		}*/
+		}
 		
 		@Test
 		@WithMockUser(authorities = {"USER", "ADMIN"})


### PR DESCRIPTION
## Summary <!-- Add a brief description of this PR below this line -->
Implemented the solution with regex that matches years in a range of 1900-2999, months in a range of 01-12 and days in a range of 01-31. 

Used the [following article](https://www.baeldung.com/java-date-regular-expressions) as a reference.

Also uncommented tests - passes them all.

I believe the regex doesn't matches specific dates (like leap years cases or specific 30, 31 days month), the more correct regex is way too complex, maybe we could stick with the current implementation for now?

## Close issue(s) <!-- Add "Close" and the issue number below this line, for example: "Close #123" -->
Closes #131 