### PR TITLE
Implement custom validator annotation for the date in HistoryRequestDTO

### DIFF
--- a/src/main/java/app/fitbuddy/annotation/FitBuddyDate.java
+++ b/src/main/java/app/fitbuddy/annotation/FitBuddyDate.java
@@ -1,0 +1,24 @@
+package app.fitbuddy.annotation;
+
+import app.fitbuddy.annotation.validator.FitBuddyDateValidator;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
+@Constraint(validatedBy = FitBuddyDateValidator.class)
+public @interface FitBuddyDate {
+
+	String message() default "{fitbuddy.validation.message.invaliddate}";
+
+	Class<?>[] groups() default { };
+
+	Class<? extends Payload>[] payload() default { };
+
+}

--- a/src/main/java/app/fitbuddy/annotation/validator/FitBuddyDateValidator.java
+++ b/src/main/java/app/fitbuddy/annotation/validator/FitBuddyDateValidator.java
@@ -1,0 +1,35 @@
+package app.fitbuddy.annotation.validator;
+
+import app.fitbuddy.annotation.FitBuddyDate;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+@Service
+public class FitBuddyDateValidator implements ConstraintValidator<FitBuddyDate, String> {
+
+	private final String datePattern;
+
+	@Autowired
+	public FitBuddyDateValidator(@Value("${fitbuddy.validation.pattern.date:yyyy-MM-dd}") String datePattern) {
+		this.datePattern = datePattern;
+	}
+
+	@Override
+	public boolean isValid(String value, ConstraintValidatorContext context) {
+		DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern(datePattern);
+		try {
+			LocalDate.parse(value, dateTimeFormatter);
+			return true;
+		} catch (Throwable ignoredThrowable) {
+			return false;
+		}
+	}
+}

--- a/src/main/java/app/fitbuddy/annotation/validator/FitBuddyDateValidator.java
+++ b/src/main/java/app/fitbuddy/annotation/validator/FitBuddyDateValidator.java
@@ -11,24 +11,24 @@ import javax.validation.ConstraintValidatorContext;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 
 @Service
 public class FitBuddyDateValidator implements ConstraintValidator<FitBuddyDate, String> {
 
-	private final String datePattern;
+	private final DateTimeFormatter dateTimeFormatter;
 
 	@Autowired
 	public FitBuddyDateValidator(@Value("${fitbuddy.validation.pattern.date:yyyy-MM-dd}") String datePattern) {
-		this.datePattern = datePattern;
+		dateTimeFormatter = DateTimeFormatter.ofPattern(datePattern);
 	}
 
 	@Override
 	public boolean isValid(String value, ConstraintValidatorContext context) {
-		DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern(datePattern);
 		try {
 			LocalDate.parse(value, dateTimeFormatter);
 			return true;
-		} catch (Throwable ignoredThrowable) {
+		} catch (DateTimeParseException parseException) {
 			return false;
 		}
 	}

--- a/src/main/java/app/fitbuddy/dto/history/HistoryRequestDTO.java
+++ b/src/main/java/app/fitbuddy/dto/history/HistoryRequestDTO.java
@@ -5,6 +5,8 @@ import javax.validation.constraints.Positive;
 import javax.validation.constraints.PositiveOrZero;
 import javax.validation.constraints.Size;
 
+import app.fitbuddy.annotation.FitBuddyDate;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import lombok.AllArgsConstructor;
@@ -29,7 +31,7 @@ public class HistoryRequestDTO {
 	@Positive
 	private Integer reps;
 	
-	// TODO: regex pattern validation
+	@FitBuddyDate
 	private String createdOn;
 
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,3 +20,9 @@ spring.h2.console.path=/console
 
 ### Include the error message in response
 server.error.include-message=always
+
+### Validation patterns
+fitbuddy.validation.pattern.date=yyyy-MM-dd
+
+### Validation messages
+fitbuddy.validation.message.invaliddate=Invalid date

--- a/src/test/java/app/fitbuddy/controller/crud/HistoryControllerTest.java
+++ b/src/test/java/app/fitbuddy/controller/crud/HistoryControllerTest.java
@@ -66,7 +66,7 @@ class HistoryControllerTest {
 			.andExpect(status().is(302));			
 		}		
 		
-		/*@ParameterizedTest
+		@ParameterizedTest
 		@ValueSource(strings = {"abc", "1-1-2022", "01-01-2022", "2022-1-1", "2022-13-01", "2022-01-32"})
 		@WithMockUser(authorities = {"USER", "ADMIN"})		
 		void whenDateIsNotCorrect_shouldReturnBadRequest(String strDate) throws Exception {
@@ -79,7 +79,7 @@ class HistoryControllerTest {
 					.contentType(MediaType.APPLICATION_JSON)
 					.content(objectMapper.writeValueAsString(requestDTO)))			
 			.andExpect(status().isBadRequest());
-		}*/
+		}
 		
 		@Test
 		@WithMockUser(authorities = {"USER", "ADMIN"})


### PR DESCRIPTION
## Summary <!-- Add a brief description of this PR below this line -->
1. `@FitBuddyDate` default validation error message use the message `fitbuddy.validation.message.invaliddate` in application.properties
2. `FitBuddyDateValidator` class is using injected `fitbuddy.validation.pattern.date` message as date pattern for the validation (by default `yyyy-MM-dd`). Made the injection via constructor, I think it's a good way (for testing the validator class in the future perhaps)
3. Uncommented `HistoryControllerTest` tests are still passing.
## Close issue(s) <!-- Add "Close" and the issue number below this line, for example: "Close #123" -->
Closes #131 